### PR TITLE
fix(lib): Added missing variable declaration in index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 var head = document.getElementsByTagName("head")[0];
 
-for (weight of ["regular", "thin", "light", "bold", "fill", "duotone"]) {
+for (const weight of ["regular", "thin", "light", "bold", "fill", "duotone"]) {
   var link = document.createElement("link");
   link.rel = "stylesheet";
   link.type = "text/css";


### PR DESCRIPTION
I had the following error when trying to use the `<script src="https://unpkg.com/@phosphor-icons/web@2.0.3"></script>` script:

<img width="684" alt="image" src="https://github.com/phosphor-icons/web/assets/32545448/37274e43-210e-4191-9278-a434e457e2d7">

@rektdeckard Does this require a version bump?