### PR TITLE
chore(docs): add ruby-phosphor-icons in community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ All weights aside from `duotone` support ligatures, meaning that in any text usi
 - [phosphor-r](https://github.com/dreamRs/phosphoricons) ▲ Phosphor icon wrapper for R documents and applications
 - [blade-phosphor-icons](https://github.com/codeat3/blade-phosphor-icons) ▲ Phosphor icons in your Laravel Blade views
 - [wordpress-phosphor-icons-block](https://github.com/robruiz/phosphor-icons-block) ▲ Phosphor icon block for use in WordPress v5.8+
+- [ruby-phosphor-icons](https://github.com/maful/ruby-phosphor-icons) ▲ Phosphor icons for Ruby and Rails applications
 
 If you've made a port of Phosphor and you want to see it here, just open a PR [here](https://github.com/phosphor-icons/homepage)!
 


### PR DESCRIPTION
related to https://github.com/phosphor-icons/homepage/pull/286