### PR TITLE
fix: replace unpkg w/ jsdelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We use a similar approach as many other icon sets out there, providing icons as 
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://unpkg.com/@phosphor-icons/web@2.1.1/src/bold/style.css"
+      href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/bold/style.css"
     />
   </head>
   <body>
@@ -51,20 +51,20 @@ Phosphor Icons come in 6 weights: `regular`, `thin`, `light`, `bold`, `fill`, an
 <link
   rel="stylesheet"
   type="text/css"
-  href="https://unpkg.com/@phosphor-icons/web@2.1.1/src/duotone/style.css"
+  href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/duotone/style.css"
 />
 ...
 <i class="ph-duotone ph-baseball"></i>
 ```
 
-The URL format is `https://unpkg.com/@phosphor-icons/web@<VERSION>/src/<WEIGHT>/style.css`. Other common CDNs may also be used.
+The URL format is `https://cdn.jsdelivr.net/npm/@phosphor-icons/web@<VERSION>/src/<WEIGHT>/style.css`. Other common CDNs may also be used.
 
 #### Using All Weights
 
 If you intend to use all 6 weights, they can be made available by including the library as a script tag, using the base URL:
 
 ```html
-<script src="https://unpkg.com/@phosphor-icons/web@2.1.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1"></script>
 ...
 <i class="ph-light ph-address-book"></i>
 <i class="ph ph-sunglasses"></i>
@@ -121,7 +121,7 @@ All weights aside from `duotone` support ligatures, meaning that in any text usi
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://unpkg.com/@phosphor-icons/web@2.1.1/src/bold/style.css"
+      href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/bold/style.css"
     />
   </head>
   <body>

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,6 @@ for (const weight of ["regular", "thin", "light", "bold", "fill", "duotone"]) {
   link.rel = "stylesheet";
   link.type = "text/css";
   link.href =
-    "https://unpkg.com/@phosphor-icons/web@2.1.1/src/" + weight + "/style.css";
+    "https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/" + weight + "/style.css";
   head.appendChild(link);
 }

--- a/test/index.html
+++ b/test/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="https://unpkg.com/@phosphor-icons/web"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web"></script>
   </head>
   <body>
     <i class="ph-fill ph-alien" style="color: darkseagreen"></i>


### PR DESCRIPTION
UNPKG has not been actively maintained and ~~has been down since `Mar 15, 2025`~~ was down from Mar 15, 2025, 2:00 AM and down for 18 hours (https://github.com/unpkg/unpkg/issues/412). Migrating to jsDelivr means a more stable and reliant service.

The PR replaces UNPKG usage with jsDelivr in README, test cases, and the library entry points.

I recommend release a new minor version ASAP.